### PR TITLE
standalone verify function

### DIFF
--- a/nkeys/__init__.py
+++ b/nkeys/__init__.py
@@ -103,6 +103,53 @@ def valid_prefix_byte(prefix):
         return False
 
 
+def verifying_nkey_to_ed25519(public_nkey):
+    """
+    :param public_nkey: The public nkey as a bytearray.
+    :rtype nacl.signing.VerifyKey:
+    :return: PyNaCl Verifying Key
+    """
+    try:
+        decoded_nkey = base64.b32decode(public_nkey)
+    except Exception:
+        raise ErrInvalidEncoding()
+
+    if len(decoded_nkey) != 35:
+        raise ErrInvalidPublicKey()
+
+    prefix = decoded_nkey[0]
+    if not valid_public_prefix_byte(prefix):
+        raise ErrInvalidPrefixByte()
+
+    # the first byte of the base32 decoded nkey is the prefix
+    # the last two bytes of the base32 decoded nkey is the crc16 checksum
+    key_without_checksum, checksum = decoded_nkey[:-2], decoded_nkey[-2:]
+
+    if checksum != crc16_checksum(key_without_checksum):
+        raise ErrInvalidCheckSum()
+
+    # remove the nkey prefix to produce the bare ED25519 verifying key
+    bare_key = key_without_checksum[1:]
+    return nacl.signing.VerifyKey(bare_key)
+
+
+def verify(public_nkey, input, sig):
+    """
+    :param public_nkey: The public nkey as a bytearray.
+    :param input: The payload in bytes that was signed.
+    :param sig: The signature in bytes that will be verified.
+    :rtype bool:
+    :return: boolean expressing that the signature is valid.
+    """
+    vk = verifying_nkey_to_ed25519(public_nkey)
+
+    try:
+        vk.verify(input, sig)
+        return True
+    except nacl.exceptions.BadSignatureError:
+        raise ErrInvalidSignature()
+
+
 class KeyPair(object):
 
     def __init__(
@@ -146,13 +193,7 @@ class KeyPair(object):
         :rtype bool:
         :return: boolean expressing that the signature is valid.
         """
-        kp = self._keys.verify_key
-
-        try:
-            kp.verify(input, sig)
-            return True
-        except nacl.exceptions.BadSignatureError:
-            raise ErrInvalidSignature()
+        return verify(self.public_key, input, sig)
 
     @property
     def public_key(self):
@@ -174,8 +215,7 @@ class KeyPair(object):
         src.insert(0, prefix)
 
         # Calculate and include crc16 checksum
-        crc = crc16(src)
-        crc_bytes = (crc).to_bytes(2, byteorder='little')
+        crc_bytes = crc16_checksum(src)
         src.extend(crc_bytes)
 
         # Encode to base32
@@ -193,8 +233,7 @@ class KeyPair(object):
         src.insert(0, PREFIX_BYTE_PRIVATE)
 
         # Calculate and include crc16 checksum
-        crc = crc16(src)
-        crc_bytes = (crc).to_bytes(2, byteorder='little')
+        crc_bytes = crc16_checksum(src)
         src.extend(crc_bytes)
 
         base32_encoded = base64.b32encode(src)
@@ -482,6 +521,11 @@ def crc16(data):
     return crc
 
 
+def crc16_checksum(data):
+    crc = crc16(data)
+    return crc.to_bytes(2, byteorder='little')
+
+
 class NkeysError(Exception):
     pass
 
@@ -520,6 +564,12 @@ class ErrInvalidEncoding(NkeysError):
 
     def __str__(self):
         return "nkeys: invalid encoded key"
+
+
+class ErrInvalidCheckSum(NkeysError):
+
+    def __str__(self):
+        return "nkeys: invalid crc16 checksum"
 
 
 class ErrInvalidSignature(NkeysError):


### PR DESCRIPTION
hello! I hope you don't mind unsolicited PRs. :)

I found myself wanting to use the `verify` class method of `KeyPair` in the typical context where the signing key is not known. And it was simple enough to move the function out of the class (and allow the class method of the same name to call the standalone one).

Additionally, since it is no longer guaranteed that the nkey will be well-formed, validation is performed.

The existing tests cover the new standalone function without any changes.