### PR TITLE
Update supported Python versions in setup.py

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,5 @@ pynacl = "*"
 [dev-packages]
 pytest = ">=2.8.0,<4.1"
 
-[requires]
-python_version = "3.7"
-
 [scripts]
 tests = "python tests/nkeys_test.py"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.org/nats-io/nkeys.py.svg?branch=master)](http://travis-ci.org/nats-io/nkeys.py)
+[![pypi](https://img.shields.io/pypi/v/nkeys.svg)](https://pypi.org/project/nkeys)
 [![Versions](https://img.shields.io/pypi/pyversions/nkeys.svg)](https://pypi.org/project/nkeys)
 
 A public-key signature system based on [Ed25519](https://ed25519.cr.yp.to/) for the NATS ecosystem.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,11 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython'
     ],
 )


### PR DESCRIPTION
Following the https://github.com/nats-io/nkeys.py/pull/4 which updated the lib and unblocked support for newer py versions, and #5 which updated CI, also update missed supported versions in `setup.py` to make sure they show up in PyPI after release.
