### PR TITLE
Remove duplicate test_keypair_public_key test method

### DIFF
--- a/tests/nkeys_test.py
+++ b/tests/nkeys_test.py
@@ -99,22 +99,6 @@ class NkeysTest(NatsTestCase):
         with self.assertRaises(AttributeError):
             kp._seed
 
-    def test_keypair_public_key(self):
-        seed = "SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
-        encoded_seed = bytearray(seed.encode())
-        kp = nkeys.from_seed(encoded_seed)
-
-        self.assertEqual(None, kp._public_key)
-        self.assertEqual(
-            "UCK5N7N66OBOINFXAYC2ACJQYFSOD4VYNU6APEJTAVFZB2SVHLKGEW7L",
-            kp.public_key
-        )
-
-        # Confirm that the public key is wiped as well.
-        kp.wipe()
-        with self.assertRaises(AttributeError):
-            kp._public_key
-
     def test_keypair_use_seed_to_verify_signature(self):
         seed = "SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
         encoded_seed = bytearray(seed.encode())


### PR DESCRIPTION
The test method `test_keypair_public_key` was defined twice in `NkeysTest`.
The second definition silently overrides the first, which never runs.
The removed definition also had an incorrect assertion comparing bytes to a str literal.