### PR TITLE
Add permissions block to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
     pull_request:
         branches:
             - "*"
+permissions:
+    contents: read
 jobs:
     format:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     pull_request:
         branches:
             - "*"
+permissions:
+    contents: read
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict the default GITHUB_TOKEN to read-only contents access,
following the principle of least privilege for CI workflows that
only need to checkout and run checks.